### PR TITLE
minc 1.9.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Note: it is not yet possible to minimize Docker containers using the _Neurodocke
 | **Matlab Compiler Runtime** | version* | 2018a, 2012-17[a-b], 2010a |
 |                             | method | binaries (default) |
 |                             | install_path | Installation path. Default `/opt/matlabmcr-{version}`. |
-| **MINC** | version* | 1.9.15 |
+| **MINC** | version* | 1.9.15, 1.9.16 |
 |          | method | binaries (default) |
 |          | install_path | Installation path. Default `/opt/minc-{version}`. |
 | **Miniconda** | version | latest (default), all other hosted versions. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -290,7 +290,7 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
 
 ```shell
 neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
-  --minc version=1.9.15 method=binaries
+  --minc version=1.9.16 method=binaries
 ```
 
 ## Miniconda

--- a/neurodocker/templates/minc.yaml
+++ b/neurodocker/templates/minc.yaml
@@ -14,10 +14,21 @@ generic:
     dependencies:
       apt: >
         libgl1-mesa-dev libice6 libsm6 libx11-6 libxext6 libxi6 libxmu6
-        libgomp1 libjpeg62
+        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick libjpeg8
       yum: >
         libICE libSM libX11 libXext libXi libXmu libgomp libjpeg-turbo
         mesa-libGL-devel
+    env:
+      MINC_TOOLKIT: "{{ minc.install_path }}"
+      MINC_TOOLKIT_VERSION: "1.9.16-20180117"
+      PATH: "{{ minc.install_path }}/bin:{{ minc.install_path }}/pipeline:$PATH"
+      PERL5LIB: "{{ minc.install_path }}/perl:{{ minc.install_path }}/pipeline:$PERL5LIB"
+      LD_LIBRARY_PATH: "{{ minc.install_path }}/lib:{{ minc.install_path }}/lib/InsightToolkit:$LD_LIBRARY_PATH"
+      MNI_DATAPATH: "{{ minc.install_path }}/../share"
+      MINC_FORCE_V2: "1"
+      MINC_COMPRESS: "4"
+      VOLUME_CACHE_THRESHOLD: "-1"
+      MANPATH: "{{ minc.install_path }}/man:$MANPATH"
     instructions: |
       {{ minc.install_dependencies() }}
       echo "Downloading MINC, BEASTLIB, and MODELS..."

--- a/neurodocker/templates/minc.yaml
+++ b/neurodocker/templates/minc.yaml
@@ -14,7 +14,7 @@ generic:
     dependencies:
       apt: >
         libgl1-mesa-dev libice6 libsm6 libx11-6 libxext6 libxi6 libxmu6
-        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick 
+        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick bc ed libxm12-dev
       yum: >
         libICE libSM libX11 libXext libXi libXmu libgomp libjpeg-turbo
         mesa-libGL-devel

--- a/neurodocker/templates/minc.yaml
+++ b/neurodocker/templates/minc.yaml
@@ -14,7 +14,7 @@ generic:
     dependencies:
       apt: >
         libgl1-mesa-dev libice6 libsm6 libx11-6 libxext6 libxi6 libxmu6
-        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick bc ed libxm12-dev
+        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick bc ed
       yum: >
         libICE libSM libX11 libXext libXi libXmu libgomp libjpeg-turbo
         mesa-libGL-devel

--- a/neurodocker/templates/minc.yaml
+++ b/neurodocker/templates/minc.yaml
@@ -10,6 +10,7 @@ generic:
   binaries:
     urls:
       1.9.15: https://dl.dropbox.com/s/40hjzizaqi91373/minc-toolkit-1.9.15-20170529-CentOS_6.9-x86_64.tar.gz
+      1.9.16: https://dl.dropbox.com/s/u9ksy2zfqmytz3x/minc-toolkit-1.9.16-20180117-CentOS_6.10-x86_64.tar.gz
     dependencies:
       apt: >
         libgl1-mesa-dev libice6 libsm6 libx11-6 libxext6 libxi6 libxmu6

--- a/neurodocker/templates/minc.yaml
+++ b/neurodocker/templates/minc.yaml
@@ -14,7 +14,7 @@ generic:
     dependencies:
       apt: >
         libgl1-mesa-dev libice6 libsm6 libx11-6 libxext6 libxi6 libxmu6
-        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick libjpeg8
+        libgomp1 libjpeg62 libglu1-mesa libgl1-mesa-glx perl imagemagick 
       yum: >
         libICE libSM libX11 libXext libXi libXmu libgomp libjpeg-turbo
         mesa-libGL-devel


### PR DESCRIPTION
should solve issue #192 . Tested in apt (neurodebian:jessie) and yum image (centos 6.9). Commandline tools work. Visual tools almost work (GUI opens, but some buttons are missing) and there is this error:
libGL error: No matching fbConfigs or visuals found
libGL error: failed to load driver: swrast
Failed to compile vertex shader: ▒c▒
Failed to compile fragment shader: ▒c▒
Failed to compile vertex shader: ▒c▒
Failed to compile fragment shader: ▒c▒
Failed to compile vertex shader: ▒c▒
Failed to compile fragment shader: ▒c▒
