### PR TITLE
replace 7.0.0 with 7.1.0

### DIFF
--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -9,7 +9,9 @@
 generic:
   binaries:
     urls:
-      "7.0.0": https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.0.0/freesurfer-linux-centos6_x86_64-7.0.0.tar.gz
+      "7.0.1": https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.1.0/freesurfer-linux-centos6_x86_64-7.1.0.tar.gz
+      # 7.0.0 not included because it was recalled several days after release due to a bug. Replaced by 7.1.0.
+      # From FreeSurfer team: we recommend that people NOT use 7.0.0 and use 7.1.0 instead.
       "6.0.1": ftp://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz
       "6.0.0": ftp://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.0/freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.0.tar.gz
       # See https://github.com/freesurfer/freesurfer/issues/70


### PR DESCRIPTION
7.0.0 has been recalled due to a bug in the program. The bugged code has been reverted in the 7.1.0 release. FreeSurfer recommends people NOT use version 7.0.0. See https://surfer.nmr.mgh.harvard.edu/fswiki/ReleaseNotes for more information.

related to #336 