### PR TITLE
add minimal install (thanks pwighton)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,30 @@ jobs:
       - run:
           name: Install singularity
           command: |
-            source ~/.bashrc
-            curl -fsSL http://neuro.debian.net/lists/focal.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
-            curl -fsSL https://dl.dropbox.com/s/zxs209o955q6vkg/neurodebian.gpg | sudo apt-key add -
-            (sudo apt-key adv --refresh-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 || true)
-            sudo apt-get -qq update
-            sudo apt-get install -yq singularity-container
+            sudo apt-get -qq update && sudo apt-get install -yq \
+                build-essential \
+                uuid-dev \
+                libgpgme-dev \
+                squashfs-tools \
+                libseccomp-dev \
+                wget \
+                pkg-config \
+                git \
+                cryptsetup-bin
+            export VERSION=1.15.5 OS=linux ARCH=amd64 && \
+                wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+                sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
+                rm go$VERSION.$OS-$ARCH.tar.gz
+            echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
+                echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
+                source ~/.bashrc
+            export VERSION=3.7.0 && # adjust this as necessary \
+                wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+                tar -xzf singularity-${VERSION}.tar.gz && \
+                cd singularity
+            ./mconfig && \
+                make -C ./builddir && \
+                sudo make -C ./builddir install
             pip install -q --no-cache-dir singularity
       - run:
           name: Test singularity image builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 ---
 _machine_kwds: &machine_kwds
-  image: circleci/classic:201711-01
+  image: ubuntu-2004:202010-01
 
 _checkout_kwds: &checkout_kwds
   path: ~/neurodocker
@@ -68,7 +68,7 @@ jobs:
           name: Install singularity
           command: |
             source ~/.bashrc
-            curl -fsSL http://neuro.debian.net/lists/trusty.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+            curl -fsSL http://neuro.debian.net/lists/focal.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
             curl -fsSL https://dl.dropbox.com/s/zxs209o955q6vkg/neurodebian.gpg | sudo apt-key add -
             (sudo apt-key adv --refresh-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 || true)
             sudo apt-get -qq update

--- a/neurodocker/interfaces/tests/test_freesurfer.py
+++ b/neurodocker/interfaces/tests/test_freesurfer.py
@@ -8,8 +8,8 @@ class TestFreeSurfer(object):
         specs = {
             "pkg_manager": "apt",
             "instructions": [
-                ("base", "ubuntu:16.04"),
-                ("freesurfer", {"version": "6.0.0-min"}),
+                ("base", "ubuntu:20.04"),
+                ("freesurfer", {"version": "7.1.1-min"}),
                 ("user", "neuro"),
             ],
         }
@@ -23,8 +23,8 @@ class TestFreeSurfer(object):
         specs = {
             "pkg_manager": "apt",
             "instructions": [
-                ("base", "docker://ubuntu:16.04"),
-                ("freesurfer", {"version": "6.0.0-min"}),
+                ("base", "docker://ubuntu:20.04"),
+                ("freesurfer", {"version": "7.1.1-min"}),
                 ("user", "neuro"),
             ],
         }

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -9,7 +9,7 @@ class TestFSL(object):
             "pkg_manager": "yum",
             "instructions": [
                 ("base", "centos:7"),
-                ("fsl", {"version": "5.0.10"}),
+                ("fsl", {"version": "6.0.4"}),
                 ("user", "neuro"),
             ],
         }
@@ -24,7 +24,7 @@ class TestFSL(object):
             "pkg_manager": "yum",
             "instructions": [
                 ("base", "docker://centos:7"),
-                ("fsl", {"version": "5.0.10"}),
+                ("fsl", {"version": "6.0.4"}),
                 ("user", "neuro"),
             ],
         }

--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -10,6 +10,7 @@ generic:
   binaries:
     urls:
       "7.1.1": https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.1.1/freesurfer-linux-centos6_x86_64-7.1.1.tar.gz
+      "7.1.1-min": https://dl.dropbox.com/s/c3earkfhhvdyuo4/freesurfer-7.1.1-min.tgz
       "7.1.0": https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.1.0/freesurfer-linux-centos6_x86_64-7.1.0.tar.gz
       # 7.0.0 not included because it was recalled several days after release due to a bug. Replaced by 7.1.0.
       # From FreeSurfer team: we recommend that people NOT use 7.0.0 and use 7.1.0 instead.

--- a/neurodocker/templates/fsl.yaml
+++ b/neurodocker/templates/fsl.yaml
@@ -11,6 +11,7 @@
 generic:
   binaries:
     urls:
+      "6.0.4": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.4-centos6_64.tar.gz
       "6.0.3": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.3-centos6_64.tar.gz
       "6.0.2": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.2-centos6_64.tar.gz
       "6.0.1": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.1-centos6_64.tar.gz


### PR DESCRIPTION
this adds a link to a minimal tarball for recon-all as described here: https://github.com/pwighton/fs-docker/blob/69419bdd6a77803ac6970a94c2b242e2f858a47c/20201127-fs711-neurodocker-min.md

the only addition was this command to get the source files included in the distribution.

```
cmd0="bash /opt/freesurfer-7.1.1/SetUpFreeSurfer.sh"
```
