### PR TITLE
add template for niftyreg

### DIFF
--- a/neurodocker/templates/niftyreg.yaml
+++ b/neurodocker/templates/niftyreg.yaml
@@ -1,0 +1,42 @@
+# Template for niftyreg.
+name: niftyreg
+source:
+  arguments:
+    required:
+    - version
+    optional:
+      install_path: /opt/niftyreg-{{ self.version }}
+      cmake_opts: -DCMAKE_INSTALL_PREFIX={{ self.install_path }} -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
+      make_opts: -j1
+  dependencies:
+    apt:
+    - ca-certificates
+    - cmake
+    - g++
+    - gcc
+    - git
+    - make
+    yum:
+    - ca-certificates
+    - cmake
+    - gcc-c++
+    - git
+    - make
+  env:
+    PATH: "{{ self.install_path }}/bin:$PATH"
+    LD_LIBRARY_PATH: "{{ self.install_path }}/lib:$LD_LIBRARY_PATH"
+  instructions: |
+    {{ self.install_dependencies() }}
+    mkdir -p /tmp/niftyreg/build
+    git clone https://github.com/KCL-BMEIS/niftyreg /tmp/niftyreg/source
+    {% if self.version != "master" and self.version != "latest" -%}
+    cd /tmp/niftyreg/source
+    git fetch --tags
+    git checkout {{ self.version }}
+    {% endif -%}
+    cd /tmp/niftyreg/build
+    cmake {{ self.cmake_opts }} /tmp/niftyreg/source
+    make {{ self.make_opts }}
+    make install
+    ldconfig
+    rm -rf /tmp/niftyreg

--- a/neurodocker/templates/niftyreg.yaml
+++ b/neurodocker/templates/niftyreg.yaml
@@ -5,6 +5,7 @@ source:
     required:
     - version
     optional:
+      repo: https://github.com/KCL-BMEIS/niftyreg
       install_path: /opt/niftyreg-{{ self.version }}
       cmake_opts: -DCMAKE_INSTALL_PREFIX={{ self.install_path }} -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
       make_opts: -j1
@@ -28,7 +29,7 @@ source:
   instructions: |
     {{ self.install_dependencies() }}
     mkdir -p /tmp/niftyreg/build
-    git clone https://github.com/KCL-BMEIS/niftyreg /tmp/niftyreg/source
+    git clone {{ self.repo }} /tmp/niftyreg/source
     {% if self.version != "master" and self.version != "latest" -%}
     cd /tmp/niftyreg/source
     git fetch --tags


### PR DESCRIPTION
@pwighton - it will probably be better to add niftyreg to the refactored version of neurodocker. the spec is a little different from the current neurodocker. i made the changes here. you can try it out with this command

```bash
docker run --rm kaczmarj/neurodocker:niftyreg generate docker \
  --pkg-manager apt \
  --base-image debian:buster-slim \
  --niftyreg version=master
```

fixes #377 
closes #379 