### PR TITLE
Parameratizing git remote for source builds

### DIFF
--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -78,6 +78,7 @@ source:
     required:
     - version
     optional:
+      fork: https://github.com/afni/afni.git
       install_path: /opt/afni-{{ self.version }}
       install_r_pkgs: "false"
       install_python3: "false"
@@ -139,7 +140,7 @@ source:
     {{ self.install_dependencies() }}
     {%- if self.install_python3.lower() in ["true", "1", "y"] %}
     {{ self.install(["python3"]) }}{% endif %}
-    git clone https://github.com/afni/afni.git {{ self.install_path }}
+    git clone {{ self.fork }} {{ self.install_path }}
     cd {{ self.install_path }}
     {% if self.version != "master" and self.version != "latest" -%}
     git fetch --tags

--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -78,7 +78,7 @@ source:
     required:
     - version
     optional:
-      fork: https://github.com/afni/afni.git
+      repo: https://github.com/afni/afni.git
       install_path: /opt/afni-{{ self.version }}
       install_r_pkgs: "false"
       install_python3: "false"
@@ -140,7 +140,7 @@ source:
     {{ self.install_dependencies() }}
     {%- if self.install_python3.lower() in ["true", "1", "y"] %}
     {{ self.install(["python3"]) }}{% endif %}
-    git clone {{ self.fork }} {{ self.install_path }}
+    git clone {{ self.repo }} {{ self.install_path }}
     cd {{ self.install_path }}
     {% if self.version != "master" and self.version != "latest" -%}
     git fetch --tags

--- a/neurodocker/templates/ants.yaml
+++ b/neurodocker/templates/ants.yaml
@@ -38,6 +38,7 @@ source:
     required:
     - version
     optional:
+      fork: https://github.com/ANTsX/ANTs.git
       install_path: /opt/ants-{{ self.version }}
       cmake_opts: -DCMAKE_INSTALL_PREFIX={{ self.install_path }} -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
       make_opts: -j1
@@ -64,7 +65,7 @@ source:
   instructions: |
     {{ self.install_dependencies() }}
     mkdir -p /tmp/ants/build
-    git clone https://github.com/ANTsX/ANTs.git /tmp/ants/source
+    git clone {{ self.fork }} /tmp/ants/source
     {% if self.version != "master" and self.version != "latest" -%}
     cd /tmp/ants/source
     git fetch --tags

--- a/neurodocker/templates/ants.yaml
+++ b/neurodocker/templates/ants.yaml
@@ -38,7 +38,7 @@ source:
     required:
     - version
     optional:
-      fork: https://github.com/ANTsX/ANTs.git
+      repo: https://github.com/ANTsX/ANTs.git
       install_path: /opt/ants-{{ self.version }}
       cmake_opts: -DCMAKE_INSTALL_PREFIX={{ self.install_path }} -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
       make_opts: -j1
@@ -65,7 +65,7 @@ source:
   instructions: |
     {{ self.install_dependencies() }}
     mkdir -p /tmp/ants/build
-    git clone {{ self.fork }} /tmp/ants/source
+    git clone {{ self.repo }} /tmp/ants/source
     {% if self.version != "master" and self.version != "latest" -%}
     cd /tmp/ants/source
     git fetch --tags

--- a/neurodocker/templates/dcm2niix.yaml
+++ b/neurodocker/templates/dcm2niix.yaml
@@ -36,6 +36,7 @@ source:
     required:
     - version
     optional:
+      fork: https://github.com/rordenlab/dcm2niix
       install_path: /opt/dcm2niix-{{ self.version }}
       cmake_opts: ""
       make_opts: -j1
@@ -62,7 +63,7 @@ source:
     PATH: "{{ self.install_path }}/bin:$PATH"
   instructions: |
     {{ self.install_dependencies() }}
-    git clone https://github.com/rordenlab/dcm2niix /tmp/dcm2niix
+    git clone {{ self.fork }} /tmp/dcm2niix
     {% if self.version != "master" and self.version != "latest" -%}
     cd /tmp/dcm2niix
     git fetch --tags

--- a/neurodocker/templates/dcm2niix.yaml
+++ b/neurodocker/templates/dcm2niix.yaml
@@ -36,7 +36,7 @@ source:
     required:
     - version
     optional:
-      fork: https://github.com/rordenlab/dcm2niix
+      repo: https://github.com/rordenlab/dcm2niix
       install_path: /opt/dcm2niix-{{ self.version }}
       cmake_opts: ""
       make_opts: -j1
@@ -63,7 +63,7 @@ source:
     PATH: "{{ self.install_path }}/bin:$PATH"
   instructions: |
     {{ self.install_dependencies() }}
-    git clone {{ self.fork }} /tmp/dcm2niix
+    git clone {{ self.repo }} /tmp/dcm2niix
     {% if self.version != "master" and self.version != "latest" -%}
     cd /tmp/dcm2niix
     git fetch --tags

--- a/neurodocker/templates/mrtrix3.yaml
+++ b/neurodocker/templates/mrtrix3.yaml
@@ -40,6 +40,7 @@ source:
     required:
     - version
     optional:
+      fork: https://github.com/MRtrix3/mrtrix3.git
       install_path: /opt/mrtrix3-{{ self.version }}
       build_processes: ""
   dependencies:
@@ -67,7 +68,7 @@ source:
   instructions: |
     {{ self.install_dependencies() }}
     mkdir -p {{ self.install_path }}
-    git clone https://github.com/MRtrix3/mrtrix3.git {{ self.install_path }}
+    git clone {{ self.fork }} {{ self.install_path }}
     cd {{ self.install_path }}
     {% if self.version != "master" and self.version != "latest" -%}
     git checkout {{ self.version }}

--- a/neurodocker/templates/mrtrix3.yaml
+++ b/neurodocker/templates/mrtrix3.yaml
@@ -40,7 +40,7 @@ source:
     required:
     - version
     optional:
-      fork: https://github.com/MRtrix3/mrtrix3.git
+      repo: https://github.com/MRtrix3/mrtrix3.git
       install_path: /opt/mrtrix3-{{ self.version }}
       build_processes: ""
   dependencies:
@@ -68,7 +68,7 @@ source:
   instructions: |
     {{ self.install_dependencies() }}
     mkdir -p {{ self.install_path }}
-    git clone {{ self.fork }} {{ self.install_path }}
+    git clone {{ self.repo }} {{ self.install_path }}
     cd {{ self.install_path }}
     {% if self.version != "master" and self.version != "latest" -%}
     git checkout {{ self.version }}


### PR DESCRIPTION
@kaczmarj, for your consideration:

This parameterizes references to git remotes.

At some point, I'd love to get FreeSurfer building from source in neurodocker, and this would be very handy for a development workflow.