### PR TITLE
fix parallel problem and quantifyThalamicNuclei.sh

### DIFF
--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -9,6 +9,7 @@
 generic:
   binaries:
     urls:
+      "7.1.1-p-patch": https://drive.google.com/uc?id=1ERngHUVbERklZHsWGYTntmdQEu_lxP0R
       "7.1.1": https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.1.1/freesurfer-linux-centos6_x86_64-7.1.1.tar.gz
       "7.1.1-min": https://dl.dropbox.com/s/c3earkfhhvdyuo4/freesurfer-7.1.1-min.tgz
       "7.1.0": https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.1.0/freesurfer-linux-centos6_x86_64-7.1.0.tar.gz


### PR DESCRIPTION
This is a patch to recon-all that removes parallelism in two places to remove race conditions that sometimes lead to failure.  One error message is "Cannot find rh.white.H".  See [here](https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/msg68263.html).  It also has the updated version of `quantifyThalamicNuclei.sh` see [here](https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/msg68433.html).
```
% diff recon-all recon-all.bak
3474,3475c3474,3481
<     if($RunIt) $fs_time $cmd |& tee -a $LF
<     if($status) goto error_exit;
---
>     if($DoParallel) then
>       set CMDF = mris_curvature_white_${hemi}.cmd
>       echo "$cmd" > $CMDF
>       set CMDFS = ( $CMDFS $CMDF )
>     else
>       if($RunIt) $fs_time $cmd |& tee -a $LF
>       if($status) goto error_exit;
>     endif
3484,3488c3490,3503
<       if($RunIt) then
<         $cmd1 | tee -a $LF
<         if($status) goto error_exit
<         $cmd2 | tee -a $LF
<         if($status) goto error_exit
---
>       if($DoParallel) then
>         set CMDF = rm_curvature_white_${hemi}.$suffix.cmd
>         echo "$cmd1" > $CMDF
>         set CMDFS = ( $CMDFS $CMDF )
>         set CMDF = ln_curvature_white_${hemi}.$suffix.cmd
>         echo "$cmd2" > $CMDF
>         set CMDFS = ( $CMDFS $CMDF )
>       else
>         if($RunIt) then
>           $cmd1 | tee -a $LF
>           if($status) goto error_exit
>           $cmd2 | tee -a $LF
>           if($status) goto error_exit
>         endif
4202c4217
< #  if($OMP_NUM_THREADS > 1) set cmd = ($cmd --parallel) # just hemis
---
>   if($OMP_NUM_THREADS > 1) set cmd = ($cmd --parallel) # just hemis
```