### PR TITLE
FIX afni installation

### DIFF
--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -64,7 +64,7 @@ class GroupAddCommonParamsAndRegisteredTemplates(click.Group):
         params: ty.List[click.Parameter] = [
             click.Option(
                 ["-p", "--pkg-manager"],
-                type=click.Choice(allowed_pkg_managers, case_sensitive=False),
+                type=click.Choice(list(allowed_pkg_managers), case_sensitive=False),
                 required=True,
                 multiple=False,
                 help="System package manager",
@@ -89,6 +89,9 @@ class OrderedParamsCommand(click.Command):
         param_order: ty.List[click.Parameter]
         opts, _, param_order = parser.parse_args(args=list(args))
         for param in param_order:
+            # We need the parameter name... so if it's None, let's panic.
+            if param.name is None:
+                raise ValueError(f"parameter name is None: {param}")
             value = opts[param.name]
             # If we have multiple values, take the first one. We do this before type
             # casting, because type casting for some reason brings all of the given
@@ -179,7 +182,7 @@ def _get_common_renderer_params() -> ty.List[click.Parameter]:
     params: ty.List[click.Parameter] = [
         click.Option(
             ["-p", "--pkg-manager"],
-            type=click.Choice(allowed_pkg_managers, case_sensitive=False),
+            type=click.Choice(list(allowed_pkg_managers), case_sensitive=False),
             required=True,
             multiple=False,
             help="System package manager",
@@ -364,6 +367,9 @@ def _get_instruction_for_param(
         d = {"name": param.name, "kwds": {"path": value}}
     # probably a registered template?
     else:
+        # We need the parameter name... so if it's None, let's panic.
+        if param.name is None:
+            raise ValueError(f"parameter name is None: {param}")
         if param.name.lower() in registered_templates():
             tmpl_name = param.name.lower()
             value = dict(value)

--- a/neurodocker/reproenv/renderers.py
+++ b/neurodocker/reproenv/renderers.py
@@ -419,9 +419,13 @@ class _Renderer:
         # Double-escape escaped sequences so that when printf is done with them, they
         # are escaped with a single slash.
         j = j.replace("\\", "\\\\")
+        # Same with parentheses.
+        j = j.replace("(", "\\(").replace(")", "\\)")
         # Add slash to the end of each line, except the last.
         j = " \\\n".join(j.splitlines())
-        cmd = f"echo '{j}' > {REPROENV_SPEC_FILE_IN_CONTAINER}"
+        # Escape the % characters so printf does not interpret them as delimiters.
+        j = j.replace("%", "%%")
+        cmd = f"printf '{j}' > {REPROENV_SPEC_FILE_IN_CONTAINER}"
         return cmd
 
 

--- a/neurodocker/reproenv/renderers.py
+++ b/neurodocker/reproenv/renderers.py
@@ -421,7 +421,7 @@ class _Renderer:
         j = j.replace("\\", "\\\\")
         # Add slash to the end of each line, except the last.
         j = " \\\n".join(j.splitlines())
-        cmd = f"printf '{j}' > {REPROENV_SPEC_FILE_IN_CONTAINER}"
+        cmd = f"echo '{j}' > {REPROENV_SPEC_FILE_IN_CONTAINER}"
         return cmd
 
 

--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -54,10 +54,10 @@ binaries:
     {{ self.install_dependencies() }}
     {%- if self.install_python3.lower() in ["true", "1", "y"] %}
     {{ self.install(["python3"]) }}
-    {% endif -%}
-    gsl2_path="$(find / -name 'libgsl.so.19' || printf '')"
-    if [ -n "$gsl2_path" ]; then \
-      ln -sfv "$gsl2_path" "$(dirname $gsl2_path)/libgsl.so.0"; \
+    {% endif %}
+    gsl_path="$(find / -name 'libgsl.so.??' || printf '')"
+    if [ -n "$gsl_path" ]; then \
+      ln -sfv "$gsl_path" "$(dirname $gsl_path)/libgsl.so.0"; \
     fi
     ldconfig
     mkdir -p {{ self.install_path }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 python_requires = >= 3.7
 install_requires =
-    click >= 7.0
+    click >= 7.0, <8.0
     etelemetry >= 0.2.0
     jinja2 >= 2.0
     jsonschema >= 3.0


### PR DESCRIPTION
Related to https://github.com/ReproNim/neurodocker/pull/378#issuecomment-844449123

This PR fixes the AFNI installation with reproenv. The first commit replaces `printf` with `echo` in the json saving command, because strings like URLs can contain `%` which `printf` thinks are directives.

Subsequent commits will fix AFNI's installation in reproenv.