### PR TITLE
afni.yaml

### DIFF
--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -29,7 +29,7 @@ generic:
       {%- if afni.pkg_manager == "apt" %}
       {{ afni.install_debs() }}
       {% endif -%}
-      gsl2_path="$(find / -name 'libgsl.so.19' || printf '')"
+      gsl2_path="$(find / -name 'libgsl.so.23' || printf '')"
       if [ -n "$gsl2_path" ]; then
         ln -sfv "$gsl2_path" "$(dirname $gsl2_path)/libgsl.so.0";
       fi

--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -29,7 +29,7 @@ generic:
       {%- if afni.pkg_manager == "apt" %}
       {{ afni.install_debs() }}
       {% endif -%}
-      gsl2_path="$(find / -name 'libgsl.so.23' || printf '')"
+      gsl2_path="$(find / -name 'libgsl.so.*' || printf '')"
       if [ -n "$gsl2_path" ]; then
         ln -sfv "$gsl2_path" "$(dirname $gsl2_path)/libgsl.so.0";
       fi


### PR DESCRIPTION
the gsl is breaking the afni because the gsl lib has been updated from 19 to 23 
`gsl2_path="$(find / -name 'libgsl.so.23' || printf '')"`