### PR TITLE
Add cat12

### DIFF
--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -99,6 +99,13 @@ neurodocker generate docker
                                     - cmake_opts [default: -DCMAKE_INSTALL_PREFIX={{ self.install_path }} -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF]
                                     - make_opts [default: -j1]
 
+    --cat12 KEY=VALUE            Add cat12
+                                    method=[binaries]
+                                    options for method=binaries
+                                    - version [required]
+                                        version=[r1933_R2017b]
+                                    - install_path [default: /opt/CAT12-{{ self.version }}]
+
     --convert3d KEY=VALUE        Add convert3d
                                     method=[binaries]
                                     options for method=binaries

--- a/docs/user_guide/examples.rst
+++ b/docs/user_guide/examples.rst
@@ -143,6 +143,8 @@ ANTS
 CAT12
 ---
 
+CAT12 requires the MCR in the correction version. Miniconda and nipype is optional but recommended to use CAT12 from NiPype.
+
 .. code-block:: bash
 
     neurodocker generate docker \
@@ -150,6 +152,9 @@ CAT12
         --pkg-manager apt \
         --mcr 2017b \
         --cat12 version=r1933_R2017b \
+        --miniconda \
+         version=latest \
+         conda_install='python=3.8 traits nipype numpy scipy h5py scikit-image' \
     > cat12-r1933_R2017b.Dockerfile
 
     docker build --tag cat12:r1933_R2017b --file cat12-r1933_R2017b.Dockerfile .

--- a/docs/user_guide/examples.rst
+++ b/docs/user_guide/examples.rst
@@ -139,6 +139,21 @@ ANTS
     docker build --tag ants:2.3.4 --file ants-234.Dockerfile .
 
 
+
+CAT12
+---
+
+.. code-block:: bash
+
+    neurodocker generate docker \
+        --base-image ubuntu:16.04 \
+        --pkg-manager apt \
+        --mcr 2017b \
+        --cat12 version=r1933_R2017b \
+    > cat12-r1933_R2017b.Dockerfile
+
+    docker build --tag cat12:r1933_R2017b --file cat12-r1933_R2017b.Dockerfile .
+
 SPM
 ---
 

--- a/neurodocker/templates/cat12.yaml
+++ b/neurodocker/templates/cat12.yaml
@@ -1,0 +1,46 @@
+# Instructions to install CAT12 toolbox with SPM.
+#
+# Website: http://141.35.69.218/cat/
+# Documentation: http://www.neuro.uni-jena.de/cat12-html/cat_versions.html
+
+
+name: cat12
+binaries:
+  arguments:
+    required:
+    - version
+    optional:
+      install_path: /opt/CAT12-{{ self.version }}
+  urls:
+    r1933_R2017b: http://www.neuro.uni-jena.de/cat12/CAT12.8_r1933_R2017b_MCR_Linux.zip
+  dependencies:
+    apt:
+    - ca-certificates
+    - curl
+    - unzip
+    yum:
+    - curl
+    - unzip
+  env:
+    FORCE_SPMMCR: "1"
+    SPM_HTML_BROWSER: "0"
+    MCR_INHIBIT_CTF_LOCK: 1
+    SPM_HTML_BROWSER: 0
+    SPMROOT: /opt/cat12_link
+    MCRROOT: /opt/mcr_link
+    MCR_INHIBIT_CTF_LOCK: 1v
+
+
+  instructions: |
+    {{ self.install_dependencies() }}
+    # Install cat12
+    echo "Downloading standalone CAT12 ..."
+    curl -fL -o /tmp/cat12.zip {{ self.urls[self.version] }}
+    unzip -q /tmp/cat12.zip -d /tmp
+    rm -rf /tmp/cat12.zip
+    mkdir -p {{ self.install_path }}
+    mv /tmp/spm12/* {{ self.install_path }}/
+    chmod -R 777 {{ self.install_path }}
+    rm -rf /tmp/spm*
+    # Test
+    {{ self.install_path }}/spm12 function exit

--- a/neurodocker/templates/cat12.yaml
+++ b/neurodocker/templates/cat12.yaml
@@ -26,10 +26,9 @@ binaries:
     SPM_HTML_BROWSER: "0"
     MCR_INHIBIT_CTF_LOCK: 1
     SPM_HTML_BROWSER: 0
-    SPMROOT: /opt/cat12_link
-    MCRROOT: /opt/mcr_link
-    MCR_INHIBIT_CTF_LOCK: 1v
-
+    SPMROOT: "{{ self.install_path }}"
+    MCR_INHIBIT_CTF_LOCK: 1
+    PATH: "{{ self.install_path }}:$PATH"
 
   instructions: |
     {{ self.install_dependencies() }}

--- a/neurodocker/templates/cat12.yaml
+++ b/neurodocker/templates/cat12.yaml
@@ -24,10 +24,10 @@ binaries:
   env:
     FORCE_SPMMCR: "1"
     SPM_HTML_BROWSER: "0"
-    MCR_INHIBIT_CTF_LOCK: 1
-    SPM_HTML_BROWSER: 0
+    MCR_INHIBIT_CTF_LOCK: "1"
+    SPM_HTML_BROWSER: "0"
     SPMROOT: "{{ self.install_path }}"
-    MCR_INHIBIT_CTF_LOCK: 1
+    MCR_INHIBIT_CTF_LOCK: "1"
     PATH: "{{ self.install_path }}:$PATH"
 
   instructions: |

--- a/neurodocker/templates/cat12.yaml
+++ b/neurodocker/templates/cat12.yaml
@@ -38,7 +38,7 @@ binaries:
     unzip -q /tmp/cat12.zip -d /tmp
     rm -rf /tmp/cat12.zip
     mkdir -p {{ self.install_path }}
-    mv /tmp/*{{ self.urls[self.version] }}*/* {{ self.install_path }}/
+    mv /tmp/*{{ self.version }}*/* {{ self.install_path }}/
     chmod -R 777 {{ self.install_path }}
     # Test
     {{ self.install_path }}/spm12 function exit

--- a/neurodocker/templates/cat12.yaml
+++ b/neurodocker/templates/cat12.yaml
@@ -38,7 +38,7 @@ binaries:
     unzip -q /tmp/cat12.zip -d /tmp
     rm -rf /tmp/cat12.zip
     mkdir -p {{ self.install_path }}
-    mv /tmp/spm12/* {{ self.install_path }}/
+    mv /tmp/*{{ self.urls[self.version] }}*/* {{ self.install_path }}/
     chmod -R 777 {{ self.install_path }}
     # Test
     {{ self.install_path }}/spm12 function exit

--- a/neurodocker/templates/cat12.yaml
+++ b/neurodocker/templates/cat12.yaml
@@ -40,6 +40,5 @@ binaries:
     mkdir -p {{ self.install_path }}
     mv /tmp/spm12/* {{ self.install_path }}/
     chmod -R 777 {{ self.install_path }}
-    rm -rf /tmp/spm*
     # Test
     {{ self.install_path }}/spm12 function exit

--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -45,6 +45,8 @@ binaries:
     - libxt6
     - multiarch-support
     - unzip
+    - openjdk-8-jre
+    - dbus-x11
     yum:
     - bc
     - curl
@@ -53,6 +55,8 @@ binaries:
     - libXpm
     - libXt.x86_64
     - unzip
+    - java-1.8.0-openjdk
+    - dbus-x11
     debs:
     - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
   env:

--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -66,6 +66,8 @@ binaries:
     MATLABCMD: "{{ self.install_path }}/{{ self.version }}/toolbox/matlab"
     XAPPLRESDIR: |
       /opt/{{ self.install_path }}/{{ versionTovXX[self.version] }}/x11/app-defaults
+    MCRROOT: "{{ self.install_path }}/{{ self.version }}"
+
   instructions: |
     export TMPDIR="$(mktemp -d)"
     {{ self.install_dependencies() }}

--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -64,6 +64,8 @@ binaries:
       {% set versionTovXX = {"2021b": "v911", "2021a": "v910", "2020b": "v99", "2020a": "v98", "2019b": "v97", "2019a": "v96", "2018b": "v95", "2018a": "v94", "2017b": "v93", "2017a": "v92", "2016b": "v91", "2016a": "v901", "2015b": "v90", "2015aSP1": "v851", "2015a": "v85", "2014b": "v84", "2014a": "v83", "2013b": "v82", "2013a": "v81", "2012b": "v80", "2012a": "v717"} -%}
       $LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:{{ self.install_path }}/{{ versionTovXX[self.version] }}/runtime/glnxa64:{{ self.install_path }}/{{ versionTovXX[self.version] }}/bin/glnxa64:{{ self.install_path }}/{{ versionTovXX[self.version] }}/sys/os/glnxa64:{{ self.install_path }}/{{ versionTovXX[self.version] }}/extern/bin/glnxa64
     MATLABCMD: "{{ self.install_path }}/{{ self.version }}/toolbox/matlab"
+    XAPPLRESDIR: |
+      /opt/{{ self.install_path }}/{{ versionTovXX[self.version] }}/x11/app-defaults
   instructions: |
     export TMPDIR="$(mktemp -d)"
     {{ self.install_dependencies() }}

--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -65,6 +65,7 @@ binaries:
       $LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:{{ self.install_path }}/{{ versionTovXX[self.version] }}/runtime/glnxa64:{{ self.install_path }}/{{ versionTovXX[self.version] }}/bin/glnxa64:{{ self.install_path }}/{{ versionTovXX[self.version] }}/sys/os/glnxa64:{{ self.install_path }}/{{ versionTovXX[self.version] }}/extern/bin/glnxa64
     MATLABCMD: "{{ self.install_path }}/{{ self.version }}/toolbox/matlab"
     XAPPLRESDIR: |
+      {% set versionTovXX = {"2021b": "v911", "2021a": "v910", "2020b": "v99", "2020a": "v98", "2019b": "v97", "2019a": "v96", "2018b": "v95", "2018a": "v94", "2017b": "v93", "2017a": "v92", "2016b": "v91", "2016a": "v901", "2015b": "v90", "2015aSP1": "v851", "2015a": "v85", "2014b": "v84", "2014a": "v83", "2013b": "v82", "2013a": "v81", "2012b": "v80", "2012a": "v717"} -%}
       /opt/{{ self.install_path }}/{{ versionTovXX[self.version] }}/x11/app-defaults
     MCRROOT: "{{ self.install_path }}/{{ self.version }}"
 


### PR DESCRIPTION
I added a template for CAT12. I tried to replicate the SPM12 template first, but I realised that hardcoding the Matlab environment in the CAT12 is not so good as the version might change in the future and it currently prevents the SPM12 template from being updated. If you like the approach of keeping the MCR out to reduce code duplication then we could also adjust the SPM12 template. It's probably not possible to combine different templates (e.g. insert the MCR template in the CAT12?)

I also had to adjust a few things in the MCR script to make the GUIs work in neurodesk - I hope that's ok.

I also tried to add documentation - I hope it's clear and helpful :)

This pull request also fixes the bug in https://github.com/ReproNim/neurodocker/issues/407

