### PR TITLE
FIX: --version output in containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,3 @@
-# Sphinx documentation.
-# The Docker image is not intended to be used to build docs.
-/docs
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Prior to this PR, the `--version` output from containers would include `dirty`, indicating uncommitted changes. This was because `/docs` was not copied into the docker images.

Before this commit, the version output looks like this:

```bash
$ docker run --rm repronim/neurodocker:0.9.1 --version
neurodocker version 0.9.1+0.gad2f3a6.dirty
```

And after this commit, the version is:

```
$ docker run --rm neurodocker --version                                                                                           
neurodocker version 0.9.1+8.gf7f2aaf
```

Note the lack of `.dirty` in the output.

By excluding `/docs` from the Docker images, we were modifying the state of the git repository, and `git status` was reporting uncommitted changes. This caused the command `neurodocker --version` to show that there were uncommitted changes (by including the `dirty` suffix in the version). We do not want users to be under the impression that the version includes uncommitted changes. Indeed, kaczmarj excluded `/docs` from the docker builds as a premature optimization... it turns out that they only consume 136 kb, which is negligible.