### PR TITLE
do not install sphinx 6.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ dev =
     pytest-reportlog >= 0.1.2
     pytest-xdist >= 2.2.0
 docs =
-    sphinx >= 3.4
+    sphinx >= 3.4, !=6.*
     pydata-sphinx-theme
     sphinxcontrib.apidoc >= 0.3
 all =


### PR DESCRIPTION
The pydata theme we are using seems to be incompatible with sphinx 6.x which was released recently. This broke the docs build. We prevent this version from being installed for the time being. The error produced with sphinx 6.x is below and is related to
https://github.com/pydata/pydata-sphinx-theme/issues/1094.

This has been fixed in pydata-sphinx-theme but has not been released yet. The fix should be part of the next release 0.13.

```
Theme error:
An error happened in rendering the page api.
Reason: UndefinedError("'logo' is undefined")
make: *** [Makefile:20: html] Error 2
```

i do not know whether this will resolve #503 