### PR TITLE
Afni missing dependencies for suma

### DIFF
--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -12,7 +12,6 @@ binaries:
       install_python3: "false"
   urls:
     latest: https://afni.nimh.nih.gov/pub/dist/tgz/linux_openmp_64.tgz
-    latest-fedora-35: https://afni.nimh.nih.gov/pub/dist/tgz/linux_fedora_35_shared.tgz
   env:
     PATH: "{{ self.install_path }}:$PATH"
     AFNI_PLUGINPATH: "{{ self.install_path }}"

--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -12,6 +12,7 @@ binaries:
       install_python3: "false"
   urls:
     latest: https://afni.nimh.nih.gov/pub/dist/tgz/linux_openmp_64.tgz
+    latest-fedora-35: https://afni.nimh.nih.gov/pub/dist/tgz/linux_fedora_35_shared.tgz
   env:
     PATH: "{{ self.install_path }}:$PATH"
     AFNI_PLUGINPATH: "{{ self.install_path }}"
@@ -64,6 +65,12 @@ binaries:
     - which
     - xorg-x11-fonts-misc
     - xorg-x11-server-Xvfb
+    - wget 
+    - mesa-dri-drivers 
+    - mesa-libGLw 
+    - which 
+    - unzip 
+    - ncurses-compat-libs 
     debs:
       - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
       - http://snapshot.debian.org/archive/debian-security/20160113T213056Z/pool/updates/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb


### PR DESCRIPTION
These dependencies prevent a crash of suma when changing the t-statistic slider in Fedora 35 (mesa-libGLw is the current suspect).