### PR TITLE
modifying value for entry point to allow -arg or --arg

### DIFF
--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -344,8 +344,9 @@ def _get_instruction_for_param(
     elif param.name == "entrypoint":
         if not isinstance(value, tuple):
             raise ValueError("expected this value to be a tuple (contact developers)")
-        value = list(value)  # convert from tuple to list
-        d = {"name": param.name, "kwds": {"args": value}}
+        value_spl = []
+        [value_spl.extend(el.split()) for el in value]
+        d = {"name": param.name, "kwds": {"args": value_spl}}
     # install
     elif param.name == "install":
         opts = None


### PR DESCRIPTION
this PR would allow to have `-arg` and `--arg` when using "", e.g. "command -arg" 

fixes #507 