### PR TITLE
Enable build of docs with Sphinx 6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,8 @@ dev =
     pytest-reportlog >= 0.1.2
     pytest-xdist >= 2.2.0
 docs =
-    sphinx >= 3.4, !=6.*
-    pydata-sphinx-theme
+    sphinx <7
+    pydata-sphinx-theme >= 0.13
     sphinxcontrib.apidoc >= 0.3
 all =
     %(minify)s


### PR DESCRIPTION
`pydata-sphinx-theme` is now compatible with Sphinx 6 since [version 0.13](https://github.com/pydata/pydata-sphinx-theme/pull/1107).

Changes in this commit:

- Add upper bound on Sphinx as recommended by `pydra-sphinx-theme`
- Add lower bound on `pydra-sphinx-theme` to force cache updates if necessary
- Drop lower bound on Sphinx, let `pydata-sphinx-theme` handle it.