### PR TITLE
Add mamba option to miniconda

### DIFF
--- a/neurodocker/templates/miniconda.yaml
+++ b/neurodocker/templates/miniconda.yaml
@@ -31,6 +31,7 @@ binaries:
       conda_opts: ""
       pip_opts: ""
       yaml_file: ""
+      mamba: "false"
   instructions: |
     {% if not self.installed.lower() in ["true", "y", "1"] -%}
     {{ self.install_dependencies() }}
@@ -43,6 +44,10 @@ binaries:
     rm -f "$conda_installer"
     {% if self.version == "latest" -%}
     conda update -yq -nbase conda
+    {% endif -%}
+    {% if self.mamba == "true" -%}
+    conda install -yq -nbase conda-libmamba-solver
+    conda config --set solver libmamba
     {% endif -%}
     # Prefer packages in conda-forge
     conda config --system --prepend channels conda-forge


### PR DESCRIPTION
We're having trouble getting conda to install pandas in a timely fashion over in the freesurfer bids app: https://github.com/bids-apps/freesurfer/pull/67

Adding an option to use the mamba solver with miniconda would solve that for us.