### PR TITLE
Added "--add" command line option to add tar files as docker layers.

### DIFF
--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -219,6 +219,14 @@ def _get_common_renderer_params() -> list[click.Parameter]:
             ),
         ),
         OptionEatAll(
+            ["--add"],
+            multiple=True,
+            type=tuple,
+            help=(
+                "Extract a tar file as a layer in the container. Provide a source and destination path."
+            ),
+        ),
+        OptionEatAll(
             ["--env"],
             multiple=True,
             type=KeyValuePair(),
@@ -339,6 +347,14 @@ def _get_instruction_for_param(ctx: click.Context, param: click.Parameter, value
         if len(value) < 2:
             raise click.ClickException("expected at least two values for --copy")
         source, destination = list(value[:-1]), value[-1]
+        d = {"name": param.name, "kwds": {"source": source, "destination": destination}}
+    # add
+    elif param.name == "add":
+        if not isinstance(value, tuple):
+            raise ValueError("expected this value to be a tuple (contact developers)")
+        if len(value) < 2:
+            raise click.ClickException("expected at least two values for --add")
+        source, destination = value
         d = {"name": param.name, "kwds": {"source": source, "destination": destination}}
     # env
     elif param.name == "env":

--- a/neurodocker/reproenv/renderers.py
+++ b/neurodocker/reproenv/renderers.py
@@ -373,6 +373,13 @@ class _Renderer:
         destination: PathType | list[PathType],
     ) -> _Renderer:
         raise NotImplementedError()
+    
+    def add(
+        self,
+        source: PathType,
+        destination: PathType,
+    ) -> _Renderer:
+        raise NotImplementedError()
 
     def env(self, **kwds: str) -> _Renderer:
         raise NotImplementedError()
@@ -481,6 +488,17 @@ class DockerRenderer(_Renderer):
         if chown is not None:
             s += f"--chown={chown} "
         s += files
+        self._parts.append(s)
+        return self
+
+    @_log_instruction
+    def add(
+        self,
+        source: PathType,
+        destination: PathType,
+    ) -> DockerRenderer:
+        """Add a Dockerfile `ADD` instruction."""
+        s = f"ADD {source} {destination}"
         self._parts.append(s)
         return self
 

--- a/neurodocker/reproenv/schemas/renderer.json
+++ b/neurodocker/reproenv/schemas/renderer.json
@@ -51,6 +51,9 @@
             "$ref": "#/definitions/copy"
           },
           {
+            "$ref": "#/definitions/add"
+          },
+          {
             "$ref": "#/definitions/env"
           },
           {
@@ -158,6 +161,37 @@
               "items": {
                 "type": "string"
               }
+            },
+            "destination": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "examples": [],
+      "additionalProperties": false
+    },
+    "add": {
+      "required": [
+        "name",
+        "kwds"
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "add"
+          ]
+        },
+        "kwds": {
+          "type": "object",
+          "required": [
+            "source",
+            "destination"
+          ],
+          "properties": {
+            "source": {
+              "type": "string"
             },
             "destination": {
               "type": "string"


### PR DESCRIPTION
The --add option allows tar files to be added to docker containers without extracting inside the container or using intermediate layers.

For example if you have a rootfs in `.tar.gz` format named `hello.tar.gz` you can use the following command to add it.

```sh
neurodocker generate docker -b ubuntu -p apt --add ./hello.tar.gz /
```

This option is not currently supported with singularity.