### PR TITLE
FIX remove comment from freesurfer env line

### DIFF
--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -71,7 +71,7 @@ binaries:
     # default freesurfer options
         FS_OVERRIDE: '0'
         FIX_VERTEX_AREA: ''
-        FSF_OUTPUT_FORMAT: nii.gz# mni env requirements
+        FSF_OUTPUT_FORMAT: nii.gz
     # mni environment requirements
         MINC_BIN_DIR: '{{ self.install_path }}/mni/bin'
         MINC_LIB_DIR: '{{ self.install_path }}/mni/lib'


### PR DESCRIPTION
In the freesurfer template there was a leftover comment that ended up in one of the env variables (`FSF_OUTPUT_FORMAT`)