### PR TITLE
FIX add default header and entrypoint to docker and singularity files

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,0 @@
-[codespell]
-ignore-words-list = softwares,didi

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = softwares,didi

--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -327,6 +327,16 @@ def _params_to_renderer_dict(ctx: click.Context, pkg_manager) -> dict:
             renderer_dict["instructions"].append(d)
     if not renderer_dict["instructions"]:
         ctx.fail("not enough instructions to generate a container specification")
+    # Add header to the instructions, after the base image.
+    renderer_dict["instructions"].insert(
+        1, {"name": "_default", "kwds": {}}
+    )
+    # Use default entrypoint if user did not specify one.
+    if "entrypoint" not in [param.name for param, _ in cmd._options]:
+        renderer_dict["instructions"].append(
+            {"name": "entrypoint", "kwds": {"args": ["/neurodocker/startup.sh"]}}
+        )
+
     return renderer_dict
 
 

--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -442,9 +442,7 @@ def _base_generate(
     # Make sure to add default instructions if they are available among the templates
     if "_default" in registered_templates():
         # Add header to the instructions, after the base image.
-        renderer_dict["instructions"].insert(
-            1, {"name": "_default", "kwds": {}}
-        )
+        renderer_dict["instructions"].insert(1, {"name": "_default", "kwds": {}})
         # Use default entrypoint if user did not specify one.
         instruction_names = [instr["name"] for instr in renderer_dict["instructions"]]
         if "entrypoint" not in instruction_names:

--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -307,6 +307,8 @@ def _get_params_for_registered_templates() -> list[click.Parameter]:
     names_tmpls = list(registered_templates_items())
     names_tmpls.sort(key=lambda r: r[0])  # sort by name
     for name, tmpl in names_tmpls:
+        if name.startswith("_"):  # Templates starting with _ are private
+            continue
         hlp = _create_help_for_template(Template(tmpl))
         param = OptionEatAll(
             [f"--{name.lower()}"], type=KeyValuePair(), multiple=True, help=hlp

--- a/neurodocker/cli/generate.py
+++ b/neurodocker/cli/generate.py
@@ -327,15 +327,17 @@ def _params_to_renderer_dict(ctx: click.Context, pkg_manager) -> dict:
             renderer_dict["instructions"].append(d)
     if not renderer_dict["instructions"]:
         ctx.fail("not enough instructions to generate a container specification")
-    # Add header to the instructions, after the base image.
-    renderer_dict["instructions"].insert(
-        1, {"name": "_default", "kwds": {}}
-    )
-    # Use default entrypoint if user did not specify one.
-    if "entrypoint" not in [param.name for param, _ in cmd._options]:
-        renderer_dict["instructions"].append(
-            {"name": "entrypoint", "kwds": {"args": ["/neurodocker/startup.sh"]}}
+
+    if "_default" in registered_templates():
+        # Add header to the instructions, after the base image.
+        renderer_dict["instructions"].insert(
+            1, {"name": "_default", "kwds": {}}
         )
+        # Use default entrypoint if user did not specify one.
+        if "entrypoint" not in [param.name for param, _ in cmd._options]:
+            renderer_dict["instructions"].append(
+                {"name": "entrypoint", "kwds": {"args": ["/neurodocker/startup.sh"]}}
+            )
 
     return renderer_dict
 

--- a/neurodocker/cli/tests/test_cli.py
+++ b/neurodocker/cli/tests/test_cli.py
@@ -177,3 +177,43 @@ def test_render_registered(cmd: str, pkg_manager: str):
     assert result.exit_code == 0, result.output
     assert "jq-1.5/jq-linux64" in result.output
     assert "jq-1.6/jq-linux64" in result.output
+
+
+# Test that we add the default header and default/custom entrypoints
+@pytest.mark.parametrize("cmd", _cmds)
+@pytest.mark.parametrize("pkg_manager", ["apt", "yum"])
+@pytest.mark.parametrize("entrypoint", ["default", "custom"])
+def test_default_header_and_entrypoint(cmd: str, pkg_manager: str, entrypoint: str):
+    runner = CliRunner()
+    cmd_ = [
+        cmd,
+        "--base-image",
+        "debian:buster",
+        "--pkg-manager",
+        pkg_manager,
+    ]
+    if entrypoint == "custom":
+        cmd_.extend(["--entrypoint", "I", "decide"])
+    result = runner.invoke(generate, cmd_)
+    assert result.exit_code == 0, result.output
+
+    if cmd == "docker":
+        assert (
+            'ND_ENTRYPOINT="/neurodocker/startup.sh"\n'
+            'RUN export ND_ENTRYPOINT="/neurodocker/startup.sh"'
+        ) in result.output
+
+        if entrypoint == "default":
+            assert '\nENTRYPOINT ["/neurodocker/startup.sh"]\n' in result.output
+        else:
+            assert '\nENTRYPOINT ["I", "decide"]\n' in result.output
+    else:
+        assert (
+            '\nexport ND_ENTRYPOINT="/neurodocker/startup.sh"\n\n'
+            '%post\nexport ND_ENTRYPOINT="/neurodocker/startup.sh"\n'
+        ) in result.output
+
+        if entrypoint == "default":
+            assert '%runscript\n/neurodocker/startup.sh\n' in result.output
+        else:
+            assert '%runscript\nI decide\n' in result.output

--- a/neurodocker/cli/tests/test_cli.py
+++ b/neurodocker/cli/tests/test_cli.py
@@ -214,6 +214,6 @@ def test_default_header_and_entrypoint(cmd: str, pkg_manager: str, entrypoint: s
         ) in result.output
 
         if entrypoint == "default":
-            assert '%runscript\n/neurodocker/startup.sh\n' in result.output
+            assert "%runscript\n/neurodocker/startup.sh\n" in result.output
         else:
-            assert '%runscript\nI decide\n' in result.output
+            assert "%runscript\nI decide\n" in result.output

--- a/neurodocker/templates/_default.yaml
+++ b/neurodocker/templates/_default.yaml
@@ -4,7 +4,7 @@
 
 # TODO: read this about locales http://jaredmarkell.com/docker-and-locales/
 
-name: _header
+name: _default
 url: n/a
 # Not actually source, but we do not want to provide URLs.
 source:
@@ -28,14 +28,14 @@ source:
         LC_ALL: en_US.UTF-8
         ND_ENTRYPOINT: /neurodocker/startup.sh
     instructions: |
-        export ND_ENTRYPOINT="{{ _header._env['ND_ENTRYPOINT'] }}"
-        {{ _header.install_dependencies() }}
-        {%- if _header.pkg_manager == "apt" %}
-        sed -i -e 's/# {{ _header._env['LC_ALL'] }} UTF-8/{{ _header._env['LC_ALL'] }} UTF-8/' /etc/locale.gen
+        export ND_ENTRYPOINT="{{ self.env['ND_ENTRYPOINT'] }}"
+        {{ self.install_dependencies() }}
+        {%- if self.pkg_manager == "apt" %}
+        sed -i -e 's/# {{ self.env['LC_ALL'] }} UTF-8/{{ self.env['LC_ALL'] }} UTF-8/' /etc/locale.gen
         dpkg-reconfigure --frontend=noninteractive locales
-        update-locale LANG="{{ _header._env['LANG'] }}"
-        {%- elif _header.pkg_manager == "yum" %}
-        localedef -i {{ _header._env['LC_ALL'].split('.')[0] }} -f {{ _header._env['LC_ALL'].split('.')[1] }} {{ _header._env['LC_ALL'] }}
+        update-locale LANG="{{ self.env['LANG'] }}"
+        {%- elif self.pkg_manager == "yum" %}
+        localedef -i {{ self.env['LC_ALL'].split('.')[0] }} -f {{ self.env['LC_ALL'].split('.')[1] }} {{ self.env['LC_ALL'] }}
         {%- endif %}
         chmod 777 /opt && chmod a+s /opt
         mkdir -p /neurodocker


### PR DESCRIPTION
Thanks to the archeological work by @yarikoptic in #620 it was relatively easy to fix. The `_header.yaml` template was not added anywhere. BTW, I had to rename the template from `_header` to `_default` because `_header` is in conflict with `SingularityRenderer._header`. Some examples before/after below:

Closes #620 

<details >
<summary> BEFORE $ neurodocker generate docker --base-image ubuntu:20.04 --pkg-manager apt</summary>                              

```
# Generated by Neurodocker and Reproenv.

FROM ubuntu:20.04

# Save specification to JSON.
RUN printf '{ \
  "pkg_manager": "apt", \
  "existing_users": [ \
    "root" \
  ], \
  "instructions": [ \
    { \
      "name": "from_", \
      "kwds": { \
        "base_image": "ubuntu:20.04" \
      } \
    } \
  ] \
}' > /.reproenv.json
# End saving to specification to JSON.
```

</details>
<details >
<summary> AFTER $ neurodocker generate docker --base-image ubuntu:20.04 --pkg-manager apt</summary>                              

```
# Generated by Neurodocker and Reproenv.

FROM ubuntu:20.04
ENV LANG="en_US.UTF-8" \
    LC_ALL="en_US.UTF-8" \
    ND_ENTRYPOINT="/neurodocker/startup.sh"
RUN export ND_ENTRYPOINT="/neurodocker/startup.sh" \
    && apt-get update -qq \
    && apt-get install -y -q --no-install-recommends \
           apt-utils \
           bzip2 \
           ca-certificates \
           curl \
           locales \
           unzip \
    && rm -rf /var/lib/apt/lists/* \
    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
    && dpkg-reconfigure --frontend=noninteractive locales \
    && update-locale LANG="en_US.UTF-8" \
    && chmod 777 /opt && chmod a+s /opt \
    && mkdir -p /neurodocker \
    && if [ ! -f "$ND_ENTRYPOINT" ]; then \
         echo '#!/usr/bin/env bash' >> "$ND_ENTRYPOINT" \
    &&   echo 'set -e' >> "$ND_ENTRYPOINT" \
    &&   echo 'export USER="${USER:=`whoami`}"' >> "$ND_ENTRYPOINT" \
    &&   echo 'if [ -n "$1" ]; then "$@"; else /usr/bin/env bash; fi' >> "$ND_ENTRYPOINT"; \
    fi \
    && chmod -R 777 /neurodocker && chmod a+s /neurodocker
ENTRYPOINT ["/neurodocker/startup.sh"]

# Save specification to JSON.
RUN printf '{ \
  "pkg_manager": "apt", \
  "existing_users": [ \
    "root" \
  ], \
  "instructions": [ \
    { \
      "name": "from_", \
      "kwds": { \
        "base_image": "ubuntu:20.04" \
      } \
    }, \
    { \
      "name": "env", \
      "kwds": { \
        "LANG": "en_US.UTF-8", \
        "LC_ALL": "en_US.UTF-8", \
        "ND_ENTRYPOINT": "/neurodocker/startup.sh" \
      } \
    }, \
    { \
      "name": "run", \
      "kwds": { \
        "command": "export ND_ENTRYPOINT=\\"/neurodocker/startup.sh\\"\\napt-get update -qq\\napt-get install -y -q --no-install-recommends \\\\\\n    apt-utils \\\\\\n    bzip2 \\\\\\n    ca-certificates \\\\\\n    curl \\\\\\n    locales \\\\\\n    unzip\\nrm -rf /var/lib/apt/lists/*\\nsed -i -e '"'"'s/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/'"'"' /etc/locale.gen\\ndpkg-reconfigure --frontend=noninteractive locales\\nupdate-locale LANG=\\"en_US.UTF-8\\"\\nchmod 777 /opt && chmod a+s /opt\\nmkdir -p /neurodocker\\nif [ ! -f \\"$ND_ENTRYPOINT\\" ]; then\\n  echo '"'"'#!/usr/bin/env bash'"'"' >> \\"$ND_ENTRYPOINT\\"\\n  echo '"'"'set -e'"'"' >> \\"$ND_ENTRYPOINT\\"\\n  echo '"'"'export USER=\\"${USER:=`whoami`}\\"'"'"' >> \\"$ND_ENTRYPOINT\\"\\n  echo '"'"'if [ -n \\"$1\\" ]; then \\"$@\\"; else /usr/bin/env bash; fi'"'"' >> \\"$ND_ENTRYPOINT\\";\\nfi\\nchmod -R 777 /neurodocker && chmod a+s /neurodocker" \
      } \
    }, \
    { \
      "name": "entrypoint", \
      "kwds": { \
        "args": [ \
          "/neurodocker/startup.sh" \
        ] \
      } \
    } \
  ] \
}' > /.reproenv.json
# End saving to specification to JSON.
```

</details>


<details >
<summary> BEFORE $ neurodocker generate singularity --base-image ubuntu:20.04 --pkg-manager apt</summary>                              

```
# Generated by Neurodocker and Reproenv.

Bootstrap: docker
From: ubuntu:20.04

%post


# Save specification to JSON.
printf '{ \
  "pkg_manager": "apt", \
  "existing_users": [ \
    "root" \
  ], \
  "instructions": [ \
    { \
      "name": "from_", \
      "kwds": { \
        "base_image": "ubuntu:20.04" \
      } \
    } \
  ] \
}' > /.reproenv.json
# End saving to specification to JSON.
```

</details>

<details >
<summary> AFTER $ neurodocker generate singularity --base-image ubuntu:20.04 --pkg-manager apt</summary>                              

```
$ neurodocker generate singularity --base-image ubuntu:20.04 --pkg-manager apt 
# Generated by Neurodocker and Reproenv.

Bootstrap: docker
From: ubuntu:20.04

%environment
export LANG="en_US.UTF-8"
export LC_ALL="en_US.UTF-8"
export ND_ENTRYPOINT="/neurodocker/startup.sh"

%post
export ND_ENTRYPOINT="/neurodocker/startup.sh"
apt-get update -qq
apt-get install -y -q --no-install-recommends \
    apt-utils \
    bzip2 \
    ca-certificates \
    curl \
    locales \
    unzip
rm -rf /var/lib/apt/lists/*
sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
dpkg-reconfigure --frontend=noninteractive locales
update-locale LANG="en_US.UTF-8"
chmod 777 /opt && chmod a+s /opt
mkdir -p /neurodocker
if [ ! -f "$ND_ENTRYPOINT" ]; then
  echo '#!/usr/bin/env bash' >> "$ND_ENTRYPOINT"
  echo 'set -e' >> "$ND_ENTRYPOINT"
  echo 'export USER="${USER:=`whoami`}"' >> "$ND_ENTRYPOINT"
  echo 'if [ -n "$1" ]; then "$@"; else /usr/bin/env bash; fi' >> "$ND_ENTRYPOINT";
fi
chmod -R 777 /neurodocker && chmod a+s /neurodocker

# Save specification to JSON.
printf '{ \
  "pkg_manager": "apt", \
  "existing_users": [ \
    "root" \
  ], \
  "instructions": [ \
    { \
      "name": "from_", \
      "kwds": { \
        "base_image": "ubuntu:20.04" \
      } \
    }, \
    { \
      "name": "env", \
      "kwds": { \
        "LANG": "en_US.UTF-8", \
        "LC_ALL": "en_US.UTF-8", \
        "ND_ENTRYPOINT": "/neurodocker/startup.sh" \
      } \
    }, \
    { \
      "name": "run", \
      "kwds": { \
        "command": "export ND_ENTRYPOINT=\\"/neurodocker/startup.sh\\"\\napt-get update -qq\\napt-get install -y -q --no-install-recommends \\\\\\n    apt-utils \\\\\\n    bzip2 \\\\\\n    ca-certificates \\\\\\n    curl \\\\\\n    locales \\\\\\n    unzip\\nrm -rf /var/lib/apt/lists/*\\nsed -i -e '"'"'s/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/'"'"' /etc/locale.gen\\ndpkg-reconfigure --frontend=noninteractive locales\\nupdate-locale LANG=\\"en_US.UTF-8\\"\\nchmod 777 /opt && chmod a+s /opt\\nmkdir -p /neurodocker\\nif [ ! -f \\"$ND_ENTRYPOINT\\" ]; then\\n  echo '"'"'#!/usr/bin/env bash'"'"' >> \\"$ND_ENTRYPOINT\\"\\n  echo '"'"'set -e'"'"' >> \\"$ND_ENTRYPOINT\\"\\n  echo '"'"'export USER=\\"${USER:=`whoami`}\\"'"'"' >> \\"$ND_ENTRYPOINT\\"\\n  echo '"'"'if [ -n \\"$1\\" ]; then \\"$@\\"; else /usr/bin/env bash; fi'"'"' >> \\"$ND_ENTRYPOINT\\";\\nfi\\nchmod -R 777 /neurodocker && chmod a+s /neurodocker" \
      } \
    }, \
    { \
      "name": "entrypoint", \
      "kwds": { \
        "args": [ \
          "/neurodocker/startup.sh" \
        ] \
      } \
    } \
  ] \
}' > /.reproenv.json
# End saving to specification to JSON.

%runscript
/neurodocker/startup.sh
```

</details>