### PR TITLE
FIX use --transform in freesurfer's template to generalize across freesurfer versions to strip leading `freesurfer/` folder

### DIFF
--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -84,7 +84,7 @@ binaries:
         echo "Downloading FreeSurfer ..."
         mkdir -p {{ self.install_path }}
         curl -fL {{ self.urls[self.version] }} \
-        | tar -xz -C {{ self.install_path }} --owner root --group root --no-same-owner --strip-components 1 {% if self.exclude_paths -%}\
+        | tar -xz -C {{ self.install_path }} --owner root --group root --no-same-owner --strip-components {% if self.version in ("7.4.1") %}2{% else %}1{% endif %} {% if self.exclude_paths -%}\
         {%- for exclude_path in self.exclude_paths.split() %}
           {% if not loop.last -%}
           --exclude='{{ exclude_path }}' \

--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -84,7 +84,7 @@ binaries:
         echo "Downloading FreeSurfer ..."
         mkdir -p {{ self.install_path }}
         curl -fL {{ self.urls[self.version] }} \
-        | tar -xz -C {{ self.install_path }} --owner root --group root --no-same-owner --strip-components {% if self.version in ("7.4.1") %}2{% else %}1{% endif %} {% if self.exclude_paths -%}\
+        | tar -xz -C {{ self.install_path }} --owner root --group root --no-same-owner --transform='s,freesurfer/,,' {% if self.exclude_paths -%}\
         {%- for exclude_path in self.exclude_paths.split() %}
           {% if not loop.last -%}
           --exclude='{{ exclude_path }}' \


### PR DESCRIPTION
I guess we'll have to check if the same problem occurs with new freesurfer versions.

Closes #625 