### PR TITLE
Fix Centos outdated mirror link

### DIFF
--- a/neurodocker/templates/_default.yaml
+++ b/neurodocker/templates/_default.yaml
@@ -19,9 +19,7 @@ source:
         yum:
         -   bzip2
         -   ca-certificates
-        -   curl
         -   epel-release
-        -   localedef
         -   unzip
     env:
         LANG: en_US.UTF-8
@@ -29,6 +27,10 @@ source:
         ND_ENTRYPOINT: /neurodocker/startup.sh
     instructions: |
         export ND_ENTRYPOINT="{{ self.env['ND_ENTRYPOINT'] }}"
+        {%- if self.pkg_manager == "yum" %}
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        {%- endif %}
         {{ self.install_dependencies() }}
         {%- if self.pkg_manager == "apt" %}
         sed -i -e 's/# {{ self.env['LC_ALL'] }} UTF-8/{{ self.env['LC_ALL'] }} UTF-8/' /etc/locale.gen


### PR DESCRIPTION
Changed mirror link to http://vault.centos.org to retrieve yum packages. 
Removed curl and localedef in dependencies.