### PR TITLE
Update freesurfer.yaml

### DIFF
--- a/neurodocker/templates/freesurfer.yaml
+++ b/neurodocker/templates/freesurfer.yaml
@@ -71,7 +71,7 @@ binaries:
     # default freesurfer options
         FS_OVERRIDE: '0'
         FIX_VERTEX_AREA: ''
-        FSF_OUTPUT_FORMAT: nii.gz
+        FSF_OUTPUT_FORMAT: 'nii.gz'
     # mni environment requirements
         MINC_BIN_DIR: '{{ self.install_path }}/mni/bin'
         MINC_LIB_DIR: '{{ self.install_path }}/mni/lib'


### PR DESCRIPTION
the way it was currently specifified was causing the next comment to be part of the variable: 
```
ENV FSF_OUTPUT_FORMAT="nii.gz# mni env requirements"
```

but should have been:
```
ENV FSF_OUTPUT_FORMAT=".nii.gz"
```