### PR TITLE
Fixes bug in determining whether to unzip or untar ANTs download

### DIFF
--- a/neurodocker/templates/ants.yaml
+++ b/neurodocker/templates/ants.yaml
@@ -10,7 +10,17 @@ binaries:
         optional:
             install_path: /opt/ants-{{ self.version }}
     urls:
+    
     # Official binaries are provided as of 2.4.1 (https://github.com/ANTsX/ANTs/releases)
+        2.6.2: https://github.com/ANTsX/ANTs/releases/download/v2.6.2/ants-2.6.2-centos7-X64-gcc.zip
+        2.6.1: https://github.com/ANTsX/ANTs/releases/download/v2.6.1/ants-2.6.1-centos7-X64-gcc.zip
+        2.6.0: https://github.com/ANTsX/ANTs/releases/download/v2.6.0/ants-2.6.0-centos7-X64-gcc.zip
+        2.5.4: https://github.com/ANTsX/ANTs/releases/download/v2.5.4/ants-2.5.4-centos7-X64-gcc.zip
+        2.5.3: https://github.com/ANTsX/ANTs/releases/download/v2.5.3/ants-2.5.3-centos7-X64-gcc.zip
+        2.5.2: https://github.com/ANTsX/ANTs/releases/download/v2.5.2/ants-2.5.2-centos7-X64-gcc.zip
+        2.5.1: https://github.com/ANTsX/ANTs/releases/download/v2.5.1/ants-2.5.1-centos7-X64-gcc.zip
+        2.5.0: https://github.com/ANTsX/ANTs/releases/download/v2.5.0/ants-2.5.0-centos7-X64-gcc.zip
+        2.4.4: https://github.com/ANTsX/ANTs/releases/download/v2.4.4/ants-2.4.4-centos7-X64-gcc.zip
         2.4.3: https://github.com/ANTsX/ANTs/releases/download/v2.4.3/ants-2.4.3-centos7-X64-gcc.zip
         2.4.2: https://github.com/ANTsX/ANTs/releases/download/v2.4.2/ants-2.4.2-centos7-X64-gcc.zip
         2.4.1: https://github.com/ANTsX/ANTs/releases/download/v2.4.1/ants-2.4.1-centos7-X64-gcc.zip

--- a/neurodocker/templates/ants.yaml
+++ b/neurodocker/templates/ants.yaml
@@ -47,7 +47,7 @@ binaries:
     instructions: |
         {{ self.install_dependencies() }}
         echo "Downloading ANTs ..."
-        {% if (self.version == "2.4.1" or self.version == "2.4.2" or self.version == "2.4.3") -%}
+        {% if (self.version == "2.4.1" or self.version == "2.4.2" or self.version == "2.4.3" or self.version == "2.4.4" or self.version == "2.5.0" or self.version == "2.5.1" or self.version == "2.5.2" or self.version == "2.5.3" or self.version == "2.5.4" or self.version == "2.6.0" or self.version == "2.6.1" or self.version == "2.6.2") -%}
         curl -fsSL -o ants.zip {{ self.urls[self.version] }}
         unzip ants.zip -d /opt
         mv {{ self.install_path }}/bin/* {{ self.install_path }}


### PR DESCRIPTION
After 2.4.1 ANTs switched to zipping its releases and so the template needs to check the versions. The newly added versions weren't included in this check