### PR TITLE
Add mypy and types-PyYAML to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,13 @@ dev = [
     "neurodocker[minify]",
     "codecov",
     "coverage[toml]",
+    "mypy",
     "pre-commit",
     "pytest >= 6.0",
     "pytest-cov >= 2.0.0",
     "pytest-reportlog >= 0.1.2",
-    "pytest-xdist >= 2.2.0"
+    "pytest-xdist >= 2.2.0",
+    "types-PyYAML"
 ]
 doc = [
     "sphinx <7",


### PR DESCRIPTION
Allows running mypy locally without --install-types, which requires pip and fails in uv-managed venvs.

Prior attempt to release did not work since push of master failed due to protections, I pruned the tag commit, disabled master protection -- we will try release again if all green.