### PR TITLE
Add auto-version query step and push Docker master tag on every build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,26 +40,39 @@ jobs:
                 wget -O- "$auto_download_url" | gunzip > ~/auto
                 chmod a+x ~/auto
 
+        -   name: Query 'auto' on type of the release
+            id: auto-version
+            run: |
+                set -o pipefail
+                ~/auto version -vv | tee /tmp/auto-version
+                version="$(sed -ne '/Calculated SEMVER bump:/s,.*: *,,p' /tmp/auto-version)"
+                echo "version=$version" >> "$GITHUB_OUTPUT"
+            env:
+                GH_TOKEN: ${{ secrets.AUTO_USER_TOKEN }}
+
         -   name: Create release
+            if: steps.auto-version.outputs.version != ''
             run: |
                 ~/auto shipit -vv
             env:
                 GH_TOKEN: ${{ secrets.AUTO_USER_TOKEN }}
 
-        -   name: Build Docker images
-            if: steps.auto-version.outputs.version != ''
-            run: |
-                docker build \
-                  -t repronim/neurodocker:master \
-                  -t repronim/neurodocker:latest \
-                  -t repronim/neurodocker:"$(git describe | sed -e 's,^v,,g')" \
-                  .
-
-        -   name: Push Docker images
-            if: steps.auto-version.outputs.version != ''
+        -   name: Login to Docker Hub
             run: |
                 docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
-                docker push --all-tags repronim/neurodocker
             env:
                 DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
                 DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
+        -   name: Build and push master Docker image
+            run: |
+                docker build -t repronim/neurodocker:master .
+                docker push repronim/neurodocker:master
+
+        -   name: Build and push release Docker images
+            if: steps.auto-version.outputs.version != ''
+            run: |
+                docker tag repronim/neurodocker:master repronim/neurodocker:latest
+                docker tag repronim/neurodocker:master repronim/neurodocker:"$(git describe | sed -e 's,^v,,g')"
+                docker push repronim/neurodocker:latest
+                docker push repronim/neurodocker:"$(git describe | sed -e 's,^v,,g')"


### PR DESCRIPTION
The Docker build/push steps referenced steps.auto-version.outputs.version but no step with id auto-version existed, so Docker images were never built. Add the auto-version query step (as in heudiconv) so releases actually trigger Docker pushes. Also restructure so the master tag is built and pushed on every push to master, while latest and version tags are only pushed on actual releases.

I will merge right away since changes only to workflow operating only on master.