### PR TITLE
Get rid of setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-# [options.package_data]
-# neurodocker =
-#     templates/*.yaml
-#     reproenv/schemas/*.json
-#     cli/minify/_trace.sh


### PR DESCRIPTION
The sdist doesn't change when uncommenting the comments in this file. It seems useless as it is.

I understand [options.package_data](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data) in `setup.cfg` is specific to setuptools. See #607, which changed the build system to hatchling and removed or commented everything in `setup.cfg`.