### PR TITLE
pre-commit → prek

### DIFF
--- a/.github/workflows/run_precommit.yml
+++ b/.github/workflows/run_precommit.yml
@@ -1,5 +1,5 @@
 ---
-name: pre-commit
+name: prek
 
 on:
     pull_request:
@@ -7,9 +7,8 @@ on:
         branches: [master]
 
 jobs:
-    pre-commit:
+    prek:
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/setup-python@v6
         -   uses: actions/checkout@v6
-        -   uses: pre-commit/action@v3.0.1
+        -   uses: j178/prek-action@v1

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -38,10 +38,10 @@ jobs:
             with:
                 python-version: '3.12'
                 allow-prereleases: false
-        -   name: Install pre-commit
-            run: pip install pre-commit
+        -   name: Install prek
+            run: pip install prek
         -   name: Update pre-commit hooks
-            run: pre-commit autoupdate
+            run: prek auto-update
         -   name: Create Pull Request
             uses: peter-evans/create-pull-request@v8
             with:

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ cd neurodocker
 python -m pip install --no-cache-dir --editable .[all]
 ```
 
-Before committing changes, initialize `pre-commit` with `pre-commit install`. This will format code with each commit to keep the style consistent. _Neurodocker_ uses `ruff` for formatting.
+Before committing changes, initialize `prek` with `prek install`, or `pre-commit` with `pre-commit install`. This will format code with each commit to keep the style consistent. _Neurodocker_ uses `ruff` for formatting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "codecov",
     "coverage[toml]",
     "mypy",
-    "pre-commit",
+    "prek",
     "pytest >= 6.0",
     "pytest-cov >= 2.0.0",
     "pytest-reportlog >= 0.1.2",


### PR DESCRIPTION
Attempt to use [`prek`](https://prek.j178.dev/) instead of `pre-commit`.

This PR switches from `pre-commit` to `prek` mostly in CI.

Since `prek` is a drop-in replacement for `pre-commit`, either of them can be used on developers' computers, based on the same `.pre-commit-config.yaml` file, so that developer can change at their pace without disruption.