### PR TITLE
Add FSL 6.0.7.20, 6.0.7.21, 6.0.7.22 to fsl template

### DIFF
--- a/neurodocker/templates/fsl.yaml
+++ b/neurodocker/templates/fsl.yaml
@@ -20,6 +20,9 @@ binaries:
             install_path: /opt/fsl-{{ self.version }}
             exclude_paths: ''
     urls:
+        6.0.7.22: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
+        6.0.7.21: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
+        6.0.7.20: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
         6.0.7.19: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
         6.0.7.18: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
         6.0.7.16: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py


### PR DESCRIPTION
## Summary
- Add three missing FSL releases to the fsl.yaml template: 6.0.7.20, 6.0.7.21, 6.0.7.22
- All use the same `fslinstaller.py` installer as existing 6.0.7.x entries
- 6.0.7.22 (released 2026-03-27) includes `applywarp` performance/memory improvements and XTRACT fixes

Release notes: https://fsl.fmrib.ox.ac.uk/fsl/docs/development/history/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)