### PR TITLE
Fix #716: scope <base> tag override to docs index page

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,7 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+{% if pagename == 'index' %}
+<base href="/neurodocker/">
+{% endif %}
+{{ super() }}
+{% endblock %}


### PR DESCRIPTION
Closes #716.

When the docs are loaded at `repronim.org/neurodocker` (no trailing slash, e.g. from Google), relative `_static/...` URLs resolve against the domain root and 404, rendering the page unstyled. A Netlify redirect can't fix it (trailing-slash normalization makes `/neurodocker → /neurodocker/` loop), and a universal HTML `<base>` breaks subpages (their `../_static/...` URLs resolve UP past the base).

This restricts `<base href="/neurodocker/">` to the index page only — the only URL where the bug manifests, and the only page whose asset URLs don't contain `..` (so the base can't break them).

| Before (`/neurodocker`) | After (with fix) |
|---|---|
| ![before](https://github.com/lobennett/neurodocker/raw/assets/docs-screenshots/issue-716-before.png) | ![after](https://github.com/lobennett/neurodocker/raw/assets/docs-screenshots/issue-716-after.png) |

**Verified locally:** index at both URL forms, all 26 subpages, search, dark-mode persistence, mobile viewports, and external `#fragment` arrival — all clean (Playwright). Subpages are unchanged (no `<base>` tag emitted).
